### PR TITLE
Remove static/class method

### DIFF
--- a/Cheetah/legacy_parser.py
+++ b/Cheetah/legacy_parser.py
@@ -1257,15 +1257,21 @@ class LegacyParser(_LowLevelParser):
         isLineClearToStartToken = self.isLineClearToStartToken()
         endOfFirstLinePos = self.findEOL()
         self.getDirectiveStartToken()
-        decoratorExpr = self.getExpression()
-        self._compiler.addDecorator(decoratorExpr)
+        decorator_expr = self.getExpression()
+        if decorator_expr in ('@classmethod', '@staticmethod'):
+            self.setPos(self.pos() - len(decorator_expr))
+            raise ParseError(
+                self, '@classmethod / @staticmethod are not supported',
+            )
+        self._compiler.addDecorator(decorator_expr)
         self._eatRestOfDirectiveTag(isLineClearToStartToken, endOfFirstLinePos)
         self.getWhiteSpace()
 
         directiveName = self.matchDirective()
         if not directiveName or directiveName not in ('def', 'block', '@'):
             raise ParseError(
-                self, msg='Expected #def, #block or another @decorator')
+                self, 'Expected #def, #block or another @decorator',
+            )
         self.eatDirective()
 
     def eatDef(self):

--- a/tests/Parser_test.py
+++ b/tests/Parser_test.py
@@ -2,6 +2,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import pytest
+
 from Cheetah.compile import compile_to_class
 from Cheetah.legacy_parser import ArgList
 from Cheetah.legacy_parser import UnknownDirectiveError
@@ -543,4 +545,28 @@ def test_macros_with_arguments():
             'src\n'
             '#end herp_macro\n',
             settings={'macroDirectives': {'herp_macro': herp_macro}},
+        )
+
+
+@pytest.mark.parametrize('decorator', ('@classmethod', '@staticmethod'))
+def test_classmethod_staticmethod_not_allowed(decorator):
+    with assert_raises_exactly(
+        ParseError,
+        '\n\n'
+        '@classmethod / @staticmethod are not supported\n'
+        'Line 1, column 2\n'
+        '\n'
+        'Line|Cheetah Code\n'
+        '----|-------------------------------------------------------------\n'
+        '1   |#{0}\n'
+        '      ^\n'
+        '2   |#def foo(bar)\n'
+        '3   |    #return bar + 1\n'
+        '4   |#end def\n'.format(decorator)
+    ):
+        compile_to_class(
+            '#{0}\n'
+            '#def foo(bar)\n'
+            '    #return bar + 1\n'
+            '#end def\n'.format(decorator)
         )

--- a/tests/Regressions_test.py
+++ b/tests/Regressions_test.py
@@ -2,7 +2,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import pytest
-import unittest
 
 from Cheetah.compile import compile_to_class
 
@@ -72,7 +71,7 @@ def test_ImportFailModule():
             #set invalidmodule = dict(FOO='BAR!')
         #end try
 
-        $invalidmodule.FOO
+        $invalidmodule['FOO']
     '''
     template = compile_to_class(
         template,
@@ -80,7 +79,7 @@ def test_ImportFailModule():
     )
     template = template(searchList=[{}])
 
-    assert str(template), 'We weren\'t able to properly generate the result from the template'
+    assert template.respond()
 
 
 def test_ProperImportOfBadModule():
@@ -122,61 +121,3 @@ def test_RequestInSearchList():
     template = compile_to_class("$request")
     template = template(searchList=[{'request': 'foobar'}])
     assert template.respond() == 'foobar'
-
-
-@pytest.mark.xfail
-def test_Mantis_Issue_21():
-    """Test case for bug outlined in issue #21
-
-    Effectively @staticmethod and @classmethod
-    decorated methods in templates don't
-    properly define the _filter local, which breaks
-    when using the NameMapper
-    """
-    template = '''
-        #@staticmethod
-        #def testMethod(output=None)
-            This is my $output
-        #end def
-    '''
-    template = compile_to_class(template)
-    # raises a NameError: global name 'self' is not defined
-    assert template.testMethod(output='bug')
-
-
-class Mantis_Issue_22_Regression_Test(unittest.TestCase):
-    '''
-        Test case for bug outlined in issue #22
-
-        When using @staticmethod and @classmethod
-        in conjunction with the #filter directive
-        the generated code for the #filter is reliant
-        on the `self` local, breaking the function
-    '''
-    @pytest.mark.xfail
-    def test_NoneFilter(self):
-        template = '''
-            #@staticmethod
-            #def testMethod()
-                #filter None
-                    This is my $output
-                #end filter
-            #end def
-        '''
-        template = compile_to_class(template)
-        assert template
-        assert template.testMethod(output='bug')
-
-    @pytest.mark.xfail
-    def test_DefinedFilter(self):
-        template = '''
-            #@staticmethod
-            #def testMethod()
-                #filter Filter
-                    This is my $output
-                #end filter
-            #end def
-        '''
-        template = compile_to_class(template)
-        assert template
-        assert template.testMethod(output='bug')

--- a/tests/Template_test.py
+++ b/tests/Template_test.py
@@ -46,30 +46,6 @@ def test_TryExceptImportTestFailCase():
     )
 
 
-def test_ClassMethodSupport_BasicDecorator():
-    template = '''
-        #@classmethod
-        #def myClassMethod(foo)
-            #return '$foo = %s' % $foo
-        #end def
-    '''
-    template = compile_to_class(template)
-    rc = template.myClassMethod(foo='bar')
-    assert rc == '$foo = bar'
-
-
-def test_StaticMethodSupport_BasicDecorator():
-    template = '''
-        #@staticmethod
-        #def myStaticMethod(foo)
-            #return '$foo = %s' % $foo
-        #end def
-    '''
-    template = compile_to_class(template)
-    rc = template.myStaticMethod(foo='bar')
-    assert rc == '$foo = bar'
-
-
 def test_SubclassSearchListTest():
     """Verify that if we subclass Template, we can still use attributes on
     that subclass in the searchList


### PR DESCRIPTION
These were 1. broken 2. leaving a potential xss hole by doing-it-wrong with filters. 3. unused by yelp

good riddance.
