### PR TITLE
remove conditional __init__.py creation when compiling template directories

### DIFF
--- a/Cheetah/cheetah_compile.py
+++ b/Cheetah/cheetah_compile.py
@@ -51,16 +51,12 @@ def compile_directories(directories, extension='.tmpl', **kwargs):
     for directory in directories:
         for dirpath, _, filenames in os.walk(directory):
             # Compile all the files
-            has_templates = _compile_files_in_directory(
+            _compile_files_in_directory(
                 dirpath,
                 filenames,
                 extension=extension,
                 **kwargs
             )
-
-            # Don't add __init__.py if we're not a template directory
-            if not has_templates:
-                continue
 
             _touch_init_if_not_exists(dirpath)
 


### PR DESCRIPTION
We actually want to create the `__init__.py` even if a directory doesn't have templates.

For example you can have the following

```
templates/
   lib/
      foo.tmpl
```

If I call compile_directories on templates, I should get a `__init__.py` in templates
