### PR TITLE
Use io module for transactional support

### DIFF
--- a/Cheetah/DummyTransaction.py
+++ b/Cheetah/DummyTransaction.py
@@ -1,13 +1,5 @@
-"""Provides Transactional buffering support for cheetah."""
 from __future__ import unicode_literals
 
+import io
 
-class DummyTransaction(object):
-    def __init__(self):
-        self._chunks = []
-
-    def write(self, value):
-        self._chunks.append(value)
-
-    def getvalue(self):
-        return ''.join(self._chunks)
+DummyTransaction = io.StringIO  # For backwards compatibility

--- a/Cheetah/legacy_compiler.py
+++ b/Cheetah/legacy_compiler.py
@@ -284,7 +284,7 @@ class MethodCompiler(object):
         )
         self.addChunk('_orig_trans{} = self.transaction'.format(call_id))
         self.addChunk(
-            'self.transaction = _call{} = DummyTransaction()'.format(
+            'self.transaction = _call{} = io.StringIO()'.format(
                 call_id
             )
         )
@@ -331,7 +331,7 @@ class MethodCompiler(object):
 
         self.addChunk('if not self.transaction:')
         self.indent()
-        self.addChunk('self.transaction = DummyTransaction()')
+        self.addChunk('self.transaction = io.StringIO()')
         self.addChunk('_dummyTrans = True')
         self.dedent()
         self.addChunk('else:')
@@ -505,11 +505,11 @@ class LegacyCompiler(SettingsManager):
             CLASS_NAME, BASE_CLASS_NAME,
         )
         self._importStatements = [
-            'from Cheetah.DummyTransaction import DummyTransaction',
+            'import io',
             'from Cheetah.NameMapper import value_from_frame_or_search_list as VFFSL',
             'from Cheetah.Template import NO_CONTENT',
         ]
-        self._global_vars = {'DummyTransaction', 'NO_CONTENT', 'VFFSL'}
+        self._global_vars = {'io', 'NO_CONTENT', 'VFFSL'}
 
         self._gettext_scannables = []
 

--- a/Cheetah/testing/partial_template_test_case.py
+++ b/Cheetah/testing/partial_template_test_case.py
@@ -1,11 +1,11 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import io
 import unittest
 
 import pyquery
 
-from Cheetah.DummyTransaction import DummyTransaction
 from Cheetah.Template import Template
 
 
@@ -88,7 +88,7 @@ class ContextManagerPartialTemplateTestCase(PartialTemplateTestCase):
     ):
         # Simulated rendering
         assert template.transaction is None
-        template.transaction = DummyTransaction()
+        template.transaction = io.StringIO()
         with method(template, *partial_args, **partial_kwargs):
             template.transaction.write(self.context_contents)
         return template.transaction.getvalue()

--- a/bench/log/2016-05-05_11:32:47.txt
+++ b/bench/log/2016-05-05_11:32:47.txt
@@ -1,0 +1,23 @@
+================================================================================
+SHA = b8e900c54f9952df3b50f89eb2b4353f372ef931
+BEST_OF = 5
+ITERATIONS = 10
+TIME_PER_TEST = 200
+bogomips	: 5400.00
+bogomips	: 5400.00
+bogomips	: 5400.00
+bogomips	: 5400.00
+bogomips	: 5400.00
+bogomips	: 5400.00
+--------------------------------------------------------------------------------
+lookup_builtin_opt_on           133992 iterations
+lookup_dotted_sl_opt_on         12346 iterations
+lookup_global_opt_on            118177 iterations
+lookup_local_opt_on             105237 iterations
+lookup_sl_opt_on                15269 iterations
+vffsl_frame                     33682 iterations
+vffsl_sl                        14135 iterations
+vffsl_template                  14108 iterations
+write_markup                    12773 iterations
+write_text                      7395 iterations
+--------------------------------------------------------------------------------

--- a/tests/DummyTransaction_test.py
+++ b/tests/DummyTransaction_test.py
@@ -1,0 +1,10 @@
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+from Cheetah.DummyTransaction import DummyTransaction
+
+
+def test_importable_for_backwards_compatibility():
+    x = DummyTransaction()
+    x.write('foo')
+    assert x.getvalue() == 'foo'


### PR DESCRIPTION
Resolves #85

Here's a comparison of benchmarks (percentages are `(after - before) / before * 100)`

## Python 2.7

### Before
https://travis-ci.org/Yelp/yelp_cheetah/jobs/128115818
```
write_markup                    6775 iterations
write_text                      4627 iterations
```

### After
https://travis-ci.org/Yelp/yelp_cheetah/jobs/128116606
```
write_markup                    7553 iterations
write_text                      4596 iterations
```

### Percentage
```
write_markup: 11.5%
write_text: -0.7%
```

## Python 3.4

### Before
https://travis-ci.org/Yelp/yelp_cheetah/jobs/128116608
```
write_markup                    6576 iterations
write_text                      4215 iterations
```
### After
https://travis-ci.org/Yelp/yelp_cheetah/jobs/128115820
```
write_markup                    7358 iterations
write_text                      4503 iterations
```
### Percentage
```
write_markup 11.9%
write_text 6.8%
```

From running a bunch of benchmarks locally, I expect the performance increase for write_markup to be about ~11% (pretty consistently) and write_text to be about ~7%