### PR TITLE
Remove the #call directive

### DIFF
--- a/tests/compile_test.py
+++ b/tests/compile_test.py
@@ -324,11 +324,6 @@ useNameMapper = False
 
 
 #@dummydecorator
-#def foo_call_func(arg)
-    $arg
-#end def
-
-
 #def returning_function()
     #return 5
 #end def
@@ -365,11 +360,6 @@ useNameMapper = False
     #yield
     after
 #end def
-
-
-#call self.foo_call_func
-Hello world
-#end call
 
 
 #py foo = {"a": 1}

--- a/tests/filters_test.py
+++ b/tests/filters_test.py
@@ -5,13 +5,6 @@ from Cheetah.compile import compile_to_class
 
 
 def render_tmpl(template_source):
-    scope = dict(
-        # Dummy variable
-        foo='bar',
-        # No-op function, for use with #call
-        identity=lambda body: body,
-    )
-
     class notlocal(object):
         count = 0
 
@@ -20,29 +13,14 @@ def render_tmpl(template_source):
         return '<{}>{}</{}>'.format(notlocal.count, val, notlocal.count)
 
     template_cls = compile_to_class(template_source)
-    template = template_cls(scope, filter_fn=unique_filter)
+    template = template_cls({'foo': 'bar'}, filter_fn=unique_filter)
     return template.respond().strip()
 
 
 def test_def_only_filter_once():
-    output = render_tmpl("""
-        #def print_foo(): $foo
-
-        $print_foo()
-    """)
-
+    output = render_tmpl(
+        '#def print_foo(): $foo\n'
+        '$print_foo()'
+    )
     expected = '<1>bar</1>'
-    assert output == expected
-
-
-def test_transactional_filtering_naive_call():
-    # This will be filtered twice because $foo is substituted and filtered
-    # inside the #call block, the function is run, and then the return
-    # value (still containing $foo) is filtered again
-    output = render_tmpl("""
-        #def print_foo(): $foo
-
-        #call $identity # [$print_foo()] #end call
-    """)
-    expected = '<2> [<1>bar</1>] </2>'
     assert output == expected


### PR DESCRIPTION
- It is buggy: #188
- It requires code patterns that are unsafe when copy pasted (example taken from some yelpy code)
```python
# EXPLANATORY NOTE: `content` is a string of template output from between
# #call...#end, but without the Markup blessing.  We always trust template
# text, so each of these functions re-blesses.  Don't do that elsewhere.
def layout_column(content, column, id=None, classname=''):
    content = Markup(content)
    # ...
```
- The `#with` directive provides the same functionality