### PR TITLE
Simplify expression parsing

### DIFF
--- a/tests/SyntaxAndOutput_test.py
+++ b/tests/SyntaxAndOutput_test.py
@@ -256,37 +256,9 @@ class Placeholders(OutputTest):
         """2 placeholders, back-to-back"""
         self.verify("$aStr$anInt", "blarg1")
 
-    def test4(self):
-        """1 placeholder enclosed in ()"""
-        self.verify("$(aStr)", "blarg")
-
     def test5(self):
         """1 placeholder enclosed in {}"""
         self.verify("${aStr}", "blarg")
-
-    def test6(self):
-        """1 placeholder enclosed in []"""
-        self.verify("$[aStr]", "blarg")
-
-    def test7(self):
-        """1 placeholder enclosed in () + WS
-
-        Test to make sure that $(<WS><identifier>.. matches
-        """
-        self.verify("$( aStr   )", "blarg")
-
-    def test8(self):
-        """1 placeholder enclosed in {} + WS"""
-        self.verify("${ aStr   }", "blarg")
-
-    def test9(self):
-        """1 placeholder enclosed in [] + WS"""
-        self.verify("$[ aStr   ]", "blarg")
-
-    def test19(self):
-        """1 placeholder surrounded by single quotes and multiple newlines"""
-        self.verify("""'\n\n\n\n'$aStr'\n\n\n\n'""",
-                    """'\n\n\n\n'blarg'\n\n\n\n'""")
 
 
 class Placeholders_Vals(OutputTest):
@@ -364,11 +336,6 @@ class Placeholders_Esc(OutputTest):
         self.verify(r"\$var(\$_)",
                     "$var($_)")
 
-    def test5(self):
-        """2 escaped placeholders - nested and enclosed"""
-        self.verify(r"\$(var(\$_)",
-                    "$(var($_)")
-
 
 class Placeholders_Calls(OutputTest):
     def test2(self):
@@ -379,11 +346,6 @@ class Placeholders_Calls(OutputTest):
     def test3(self):
         r"""func placeholder - with (\n\n)"""
         self.verify("$aFunc(\n\n)",
-                    "Scooby")
-
-    def test4(self):
-        r"""func placeholder - with (\n\n) and $() enclosure"""
-        self.verify("$(aFunc(\n\n))",
                     "Scooby")
 
     def test5(self):
@@ -535,12 +497,6 @@ class NameMapper(OutputTest):
     def test19(self):
         """object method access, followed by complex slice"""
         self.verify("${anObj.meth1()[0: ((4//4*2)*2)//$anObj.meth1(2) ]}",
-                    "do")
-
-    def test20(self):
-        """object method access, followed by a very complex slice
-        If it can pass this one, it's safe to say it works!!"""
-        self.verify("$( anObj.meth1()[0:\n (\n(4//4*2)*2)//$anObj.meth1(2)\n ] )",
                     "do")
 
     def test21(self):
@@ -1107,13 +1063,11 @@ class IfDirective(OutputTest):
                         "")
 
     def test11(self):
-        """#if block using invalid top-level $(placeholder) syntax - should barf"""
+        """#if block using invalid top-level ${placeholder} syntax - should barf"""
 
         for badSyntax in (
                 "#if $*5*emptyString\n$aStr\n#end if\n",
                 "#if ${emptyString}\n$aStr\n#end if\n",
-                "#if $(emptyString)\n$aStr\n#end if\n",
-                "#if $[emptyString]\n$aStr\n#end if\n",
                 "#if $!emptyString\n$aStr\n#end if\n",
         ):
             with pytest.raises(ParseError):
@@ -1719,3 +1673,8 @@ def test_does_not_allow_autoself():
     )
     with pytest.raises(NotFound):
         cls().respond()
+
+
+def test_single_quote():
+    # Triggers a branch in code generation
+    assert compile_to_class("'")().respond() == "'"

--- a/tests/compile_test.py
+++ b/tests/compile_test.py
@@ -32,136 +32,6 @@ def test_compile_source_returns_text():
     assert "write('''Hello, world!''')" in ret
 
 
-def test_compile_gettext_alias_function_returns_scannable_output():
-    ret = compile_source("$_('Hello, world!')")
-    assert type(ret) is six.text_type
-    expected = """\
-def __CHEETAH_gettext_scannables():
-    _('Hello, world!')\
-"""
-    assert expected in ret
-
-
-def test_compile_gettext_function_returns_scannable_output():
-    ret = compile_source("$gettext('Hello, world!')")
-    assert type(ret) is six.text_type
-    expected = """\
-def __CHEETAH_gettext_scannables():
-    gettext('Hello, world!')\
-"""
-    assert expected in ret
-
-
-def test_compile_ngettext_function_returns_scannable_output():
-    ret = compile_source("$ngettext('${n} puppy', '${n} puppies', 1)")
-    assert type(ret) is six.text_type
-    expected = """\
-def __CHEETAH_gettext_scannables():
-    ngettext('${n} puppy', '${n} puppies', 1)\
-"""
-    assert expected in ret
-
-
-def test_compile_gettext_alias_as_attribute_function_returns_scannable_output():
-    # Use gettext functions as object's attributes
-    ret = compile_source("$translator._('Hello, world!')")
-    assert type(ret) is six.text_type
-    expected = """\
-def __CHEETAH_gettext_scannables():
-    translator._('Hello, world!')\
-"""
-    assert expected in ret
-
-
-def test_compile_gettext_as_attribute_function_returns_scannable_output():
-    ret = compile_source("$translator.gettext('Hello, world!')")
-    assert type(ret) is six.text_type
-    expected = """\
-def __CHEETAH_gettext_scannables():
-    translator.gettext('Hello, world!')\
-"""
-    assert expected in ret
-
-
-def test_compile_translator_with_name_variable_arg_and_gettext_attribute_returns_scannable_output():
-    ret = compile_source("$translator($interface_locale).gettext('Hello, world!')")
-    assert type(ret) is six.text_type
-    expected = """\
-def __CHEETAH_gettext_scannables():
-    translator(VFFSL("interface_locale", locals(), globals(), self, NS)).gettext('Hello, world!')\
-"""
-    assert expected in ret
-
-
-def test_compile_translator_with_literal_arg_and_gettext_attribute_returns_scannable_output():
-    ret = compile_source("$translator('en_US').gettext('Hello, world!')")
-    assert type(ret) is six.text_type
-    expected = """\
-def __CHEETAH_gettext_scannables():
-    translator('en_US').gettext('Hello, world!')\
-"""
-    assert expected in ret
-
-
-def test_compile_ngettext_as_attribute_function_returns_scannable_output():
-    ret = compile_source("$translator.ngettext('${n} puppy', '${n} puppies', 1)")
-    assert type(ret) is six.text_type
-    expected = """\
-def __CHEETAH_gettext_scannables():
-    translator.ngettext('${n} puppy', '${n} puppies', 1)\
-"""
-    assert expected in ret
-
-
-def test_compile_gettext_as_multi_level_attribute_function_returns_scannable_output():
-    # Verify attribute access few more levels deep
-    ret = compile_source("$foo.bar.translator._('Hello, world!')")
-    assert type(ret) is six.text_type
-    expected = """\
-def __CHEETAH_gettext_scannables():
-    foo.bar.translator._('Hello, world!')\
-"""
-    assert expected in ret
-
-
-def test_compile_gettext_as_multi_level_callable_attribute_function_returns_scannable_output():
-    # Verify attribute access few more levels deep
-    ret = compile_source("$foo.bar().baz().womp().gettext('Hello, world!')")
-    assert type(ret) is six.text_type
-    expected = """\
-def __CHEETAH_gettext_scannables():
-    foo.bar().baz().womp().gettext('Hello, world!')\
-"""
-    assert expected in ret
-
-
-def test_compile_ngettext_as_multi_level_attribute_function_returns_scannable_output():
-    ret = compile_source("$foo.translator.ngettext('${n} puppy', '${n} puppies', 1)")
-    assert type(ret) is six.text_type
-    expected = """\
-def __CHEETAH_gettext_scannables():
-    foo.translator.ngettext('${n} puppy', '${n} puppies', 1)\
-"""
-    assert expected in ret
-
-
-def test_compile_mutiple_gettext_functions_returns_scannable_output():
-    source_template = """\
-$gettext('Hello, world!')
-$_('I am hungry')
-$ngettext('${n} puppy', '${n} puppies', 1)")
-"""
-    ret = compile_source(source_template)
-    assert type(ret) is six.text_type
-    expected = """\
-def __CHEETAH_gettext_scannables():
-    gettext('Hello, world!') # generated from line 1, col 1.
-    _('I am hungry') # generated from line 2, col 1.
-    ngettext('${n} puppy', '${n} puppies', 1) # generated from line 3, col 1.
-"""
-    assert expected in ret
-
-
 def test_compile_source_with_encoding_returns_text():
     ret = compile_source('Hello, world! ☃')
     assert type(ret) is six.text_type
@@ -287,7 +157,7 @@ def test_compile_to_class_default_class_name():
 
 
 def test_compile_to_class_traceback():
-    ret = compile_to_class('$(1/0)')
+    ret = compile_to_class('${1/0}')
 
     try:
         ret().respond()


### PR DESCRIPTION
Resolves #218 
Resolves #236

Also makes #81, #183, and #189 actually possible 

High level changes:
- `${ foo }` is a syntax error -- identifiers cannot start with whitespace
- `$()` and `$[]` are no longer valid placeholders, use `${}` instead
- gettext parsing was removed -- this never worked entirely properly and you can do better by augmenting `._global_vars`, compiling, and then scan the compiled output
- `$foo()bar` no longer compiles to `foo().bar`
- newlines in expressions are preserved moar (see #236)
- escaped newlines in expressions are preserved