### PR TITLE
Use vfsl / vfns instead of vffsl vffns

### DIFF
--- a/Cheetah/legacy_compiler.py
+++ b/Cheetah/legacy_compiler.py
@@ -62,13 +62,9 @@ def _cheetah_var_to_text(
         return var.name
     else:
         if auto_self:
-            return 'VFFSL("{}", locals(), globals(), self, NS)'.format(
-                var.name,
-            )
+            return 'VFSL("{}", self, NS)'.format(var.name)
         else:
-            return 'VFFNS("{}", locals(), globals(), NS)'.format(
-                var.name,
-            )
+            return 'VFNS("{}", NS)'.format(var.name)
 
 
 def _process_comprehensions(expr_parts):
@@ -611,11 +607,11 @@ class LegacyCompiler(SettingsManager):
         )
         self._importStatements = [
             'import io',
-            'from Cheetah.NameMapper import value_from_frame_or_namespace as VFFNS',
-            'from Cheetah.NameMapper import value_from_frame_or_search_list as VFFSL',
+            'from Cheetah.NameMapper import value_from_namespace as VFNS',
+            'from Cheetah.NameMapper import value_from_search_list as VFSL',
             'from Cheetah.Template import NO_CONTENT',
         ]
-        self._global_vars = {'io', 'NO_CONTENT', 'VFFNS', 'VFFSL'}
+        self._global_vars = {'io', 'NO_CONTENT', 'VFNS', 'VFSL'}
 
     def __getattr__(self, name):
         """Provide one-way access to the methods and attributes of the

--- a/tests/Compiler_test.py
+++ b/tests/Compiler_test.py
@@ -16,7 +16,7 @@ from testing.util import run_python
 
 
 def lookup(v):
-    return 'VFFNS("{}", locals(), globals(), NS)'.format(v)
+    return 'VFNS("{}", NS)'.format(v)
 
 
 def test_templates_runnable_using_env(tmpdir):
@@ -48,7 +48,7 @@ def test_comments():
 
 def test_optimized_builtins():
     src = compile_source('$int("9001")')
-    # Instead of _v = VFFNS("int"...
+    # Instead of _v = VFNS("int"...
     assert ' _v = int("9001") #' in src
 
 

--- a/tests/SyntaxAndOutput_test.py
+++ b/tests/SyntaxAndOutput_test.py
@@ -1313,7 +1313,7 @@ $os.path.exists('.')""",
         """#from math import *
         """
 
-        self.verify("#from math import *\n$pow(1,2) $log10(10)",
+        self.verify("#from math import *\n$pow(1,2) $globals()['log10'](10)",
                     "1.0 1.0")
 
 


### PR DESCRIPTION
Now that list comprehensions and partial template functions are detected as globals, we do not need to fall back on `locals()` / `globals()`