### PR TITLE
Allow auto-self to be tunable in getVar and varExists

### DIFF
--- a/Cheetah/Template.py
+++ b/Cheetah/Template.py
@@ -9,6 +9,7 @@ import contextlib
 
 from Cheetah import filters
 from Cheetah.NameMapper import NotFound
+from Cheetah.NameMapper import value_from_namespace
 from Cheetah.NameMapper import value_from_search_list
 
 
@@ -75,25 +76,33 @@ class Template(object):
 
         self.transaction = None
 
-    def getVar(self, key, default=UNSPECIFIED):
+    def getVar(self, key, default=UNSPECIFIED, auto_self=True):
         """Get a variable from the searchList.  If the variable can't be found
         in the searchList, it returns the default value if one was given, or
         raises NameMapper.NotFound.
         """
         assert key.replace('_', '').isalnum(), key
         try:
-            return value_from_search_list(key, self, self._CHEETAH__namespace)
+            if auto_self:
+                return value_from_search_list(
+                    key, self, self._CHEETAH__namespace,
+                )
+            else:
+                return value_from_namespace(key, self._CHEETAH__namespace)
         except NotFound:
             if default is not UNSPECIFIED:
                 return default
             else:
                 raise
 
-    def varExists(self, key):
+    def varExists(self, key, auto_self=True):
         """Test if a variable name exists in the searchList."""
         assert key.replace('_', '').isalnum(), key
         try:
-            value_from_search_list(key, self, self._CHEETAH__namespace)
+            if auto_self:
+                value_from_search_list(key, self, self._CHEETAH__namespace)
+            else:
+                value_from_namespace(key, self._CHEETAH__namespace)
             return True
         except NotFound:
             return False

--- a/tests/SyntaxAndOutput_test.py
+++ b/tests/SyntaxAndOutput_test.py
@@ -1603,3 +1603,16 @@ def test_does_not_allow_autoself():
 def test_single_quote():
     # Triggers a branch in code generation
     assert compile_to_class("'")().respond() == "'"
+
+
+def test_getVar_auto_self():
+    sentinel = object()
+    inst = compile_to_class('#attr x = 1\n')()
+    assert inst.getVar('x', sentinel) == 1
+    assert inst.getVar('x', sentinel, auto_self=False) is sentinel
+
+
+def test_varExists_auto_self():
+    inst = compile_to_class('#attr x = 1\n')()
+    assert inst.varExists('x') is True
+    assert inst.varExists('x', auto_self=False) is False


### PR DESCRIPTION
Planned rollout:
- Add this parameter for the next release
- Default it to false in a release after that
- Remove it in a release after that