### PR TITLE
Warn when trying to test a non-partial template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.so
 .*.sw[a-z]
 .coverage
+/.cache
 /.idea
 /.project
 /.pydevproject

--- a/Cheetah/testing/partial_template_test_case.py
+++ b/Cheetah/testing/partial_template_test_case.py
@@ -61,6 +61,13 @@ class PartialTemplateTestCase(unittest.TestCase):
         partial_module = __import__(
             self.partial, fromlist=['__trash'], level=0,
         )
+        if not hasattr(partial_module, 'PARTIAL_TEMPLATE_CLASS'):
+            raise AssertionError(
+                'Module {} does not look like a partial template!\n'
+                'Do you have "#extends Cheetah.partial_template" at the top of your template file?'.format(
+                    partial_module,
+                )
+            )
         partial_func = getattr(partial_module, self.method)
         partial_args, partial_kwargs = self.get_partial_arguments()
         ret = self.call_partial_template(

--- a/tests/testing/partial_template_test_case_test.py
+++ b/tests/testing/partial_template_test_case_test.py
@@ -54,6 +54,17 @@ class OptimizeNamePartialTemplateBarTest(PartialTemplateTestCase):
         assert pq.text() == '9'
 
 
+def test_it_can_fail_against_non_partial_template():
+    class Failure(PartialTemplateTestCase):
+        partial = 'testing.templates.src.uses_partial'
+        method = 'render'
+
+    with pytest.raises(AssertionError) as exc_info:
+        Failure(methodName='test_partial_template').test_partial_template()
+
+    assert 'does not look like a partial template!' in exc_info.value.args[0]
+
+
 def test_it_can_fail_wrong_args():
     class Failure(PartialTemplateTestCase):
         partial = 'testing.templates.src.partial_template'


### PR DESCRIPTION
This makes the error a little more obvious when you forget to extend `partial_template` in your template.

before:
```
>       partial_func = getattr(partial_module, self.method)
E       AttributeError: module '<my module>' has no attribute 'render_thing'
```

after:
```
E           AssertionError: Module <module '<my module>' from '<my path>'> does not look like a partial template!
E           Do you have "#extends Cheetah.partial_template" at the top of your template file?
```