### PR TITLE
Remove [testenv:venv] now that `tox --devenv` is a thing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-project = Cheetah
 # These should match the travis env list
 envlist = py27,py34,py35,pypy
 skipsdist = True
@@ -14,10 +13,6 @@ commands =
     pre-commit install -f --install-hooks
     pre-commit run --all-files
     {toxinidir}/bench/runbench
-
-[testenv:venv]
-envdir = venv-{[tox]project}
-commands =
 
 [testenv:bench]
 deps =


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos