### PR TITLE
Use `not PY2` instead of `PY3` for python4.x compat

### DIFF
--- a/Cheetah/setuptools_support.py
+++ b/Cheetah/setuptools_support.py
@@ -13,7 +13,7 @@ from Cheetah.cheetah_compile import compile_directories
 def to_native(s):
     if six.PY2 and isinstance(s, six.text_type):  # pragma: no cover
         return s.encode('UTF-8')
-    elif six.PY3 and isinstance(s, bytes):  # pragma: no cover
+    elif not six.PY2 and isinstance(s, bytes):  # pragma: no cover
         return s.decode('UTF-8')
     else:  # pragma: no cover
         return s


### PR DESCRIPTION
found via [flake8-2020](https://github.com/asottile/flake8-2020)