### PR TITLE
Pin markupsafe at 1.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     packages=find_packages(exclude=('tests*', 'testing*')),
     ext_modules=[Extension("_cheetah", ["_cheetah.c"])],
     install_requires=[
-        'markupsafe',
+        'markupsafe==1.1.1',
         'six>=1.4.0',
     ],
     extras_require={


### PR DESCRIPTION
Fixes odd build issues with markupsafe 2.0.0a1 (relates to https://github.com/pallets/markupsafe/issues/119)