### PR TITLE
remove --fail-under from tox (covdefaults handles this)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ passenv = BENCH
 commands =
     coverage erase
     coverage run -m pytest {posargs:tests}
-    coverage report --fail-under 100
+    coverage report
     {toxinidir}/bench/runbench
 
 [testenv:pre-commit]


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos